### PR TITLE
Retrieve current ManagedSpan to enable explicit release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ hs_err_pid*
 .idea/
 *.iml
 
+# Eclipse
+.project
+.classpath
+.settings
+

--- a/src/main/java/io/opentracing/contrib/spanmanager/DefaultSpanManager.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/DefaultSpanManager.java
@@ -36,8 +36,6 @@ public final class DefaultSpanManager implements SpanManager {
 
     private static final Logger LOGGER = Logger.getLogger(DefaultSpanManager.class.getName());
 
-    private final ManagedSpan NOOP_MANAGED_SPAN = new LinkedManagedSpan(NoopSpan.INSTANCE, null);
-
     private static final DefaultSpanManager INSTANCE = new DefaultSpanManager();
     private final ThreadLocal<LinkedManagedSpan> managed = new ThreadLocal<LinkedManagedSpan>();
 
@@ -86,8 +84,7 @@ public final class DefaultSpanManager implements SpanManager {
 
     @Override
     public ManagedSpan current() {
-        LinkedManagedSpan current = refreshCurrent();
-        return current != null && current.span != null ? current : NOOP_MANAGED_SPAN;
+        return refreshCurrent();
     }
 
     @Override

--- a/src/main/java/io/opentracing/contrib/spanmanager/DefaultSpanManager.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/DefaultSpanManager.java
@@ -36,6 +36,8 @@ public final class DefaultSpanManager implements SpanManager {
 
     private static final Logger LOGGER = Logger.getLogger(DefaultSpanManager.class.getName());
 
+    private final ManagedSpan NO_MANAGED_SPAN = new LinkedManagedSpan(null, null);
+
     private static final DefaultSpanManager INSTANCE = new DefaultSpanManager();
     private final ThreadLocal<LinkedManagedSpan> managed = new ThreadLocal<LinkedManagedSpan>();
 
@@ -84,7 +86,8 @@ public final class DefaultSpanManager implements SpanManager {
 
     @Override
     public ManagedSpan current() {
-        return refreshCurrent();
+        LinkedManagedSpan current = refreshCurrent();
+        return current != null && current.span != null ? current : NO_MANAGED_SPAN;
     }
 
     @Override

--- a/src/main/java/io/opentracing/contrib/spanmanager/DefaultSpanManager.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/DefaultSpanManager.java
@@ -36,10 +36,10 @@ public final class DefaultSpanManager implements SpanManager {
 
     private static final Logger LOGGER = Logger.getLogger(DefaultSpanManager.class.getName());
 
+    private final ManagedSpan NOOP_MANAGED_SPAN = new LinkedManagedSpan(NoopSpan.INSTANCE, null);
+
     private static final DefaultSpanManager INSTANCE = new DefaultSpanManager();
     private final ThreadLocal<LinkedManagedSpan> managed = new ThreadLocal<LinkedManagedSpan>();
-
-    private final ManagedSpan NOOP = new LinkedManagedSpan(NoopSpan.INSTANCE, null);
 
     private DefaultSpanManager() {
     }
@@ -72,12 +72,9 @@ public final class DefaultSpanManager implements SpanManager {
     }
 
     @Override
-    public SpanManager.ManagedSpan currentSpan() {
-        SpanManager.ManagedSpan span = refreshCurrent();
-        if (span == null || span.getSpan() == null) {
-            span = NOOP;
-        }
-        return span;
+    public Span currentSpan() {
+        LinkedManagedSpan current = refreshCurrent();
+        return current != null && current.span != null ? current.span : NoopSpan.INSTANCE;
     }
 
     @Override
@@ -85,6 +82,12 @@ public final class DefaultSpanManager implements SpanManager {
         LinkedManagedSpan managedSpan = new LinkedManagedSpan(span, refreshCurrent());
         managed.set(managedSpan);
         return managedSpan;
+    }
+
+    @Override
+    public ManagedSpan current() {
+        LinkedManagedSpan current = refreshCurrent();
+        return current != null && current.span != null ? current : NOOP_MANAGED_SPAN;
     }
 
     @Override

--- a/src/main/java/io/opentracing/contrib/spanmanager/DefaultSpanManager.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/DefaultSpanManager.java
@@ -39,6 +39,8 @@ public final class DefaultSpanManager implements SpanManager {
     private static final DefaultSpanManager INSTANCE = new DefaultSpanManager();
     private final ThreadLocal<LinkedManagedSpan> managed = new ThreadLocal<LinkedManagedSpan>();
 
+    private final ManagedSpan NOOP = new LinkedManagedSpan(NoopSpan.INSTANCE, null);
+
     private DefaultSpanManager() {
     }
 
@@ -70,9 +72,12 @@ public final class DefaultSpanManager implements SpanManager {
     }
 
     @Override
-    public Span currentSpan() {
-        LinkedManagedSpan current = refreshCurrent();
-        return current != null && current.span != null ? current.span : NoopSpan.INSTANCE;
+    public SpanManager.ManagedSpan currentSpan() {
+        SpanManager.ManagedSpan span = refreshCurrent();
+        if (span == null || span.getSpan() == null) {
+            span = NOOP;
+        }
+        return span;
     }
 
     @Override

--- a/src/main/java/io/opentracing/contrib/spanmanager/SpanManager.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/SpanManager.java
@@ -46,7 +46,7 @@ public interface SpanManager {
     ManagedSpan manage(Span span);
 
     /**
-     * Return the current <{@link ManagedSpan}.
+     * Return the current {@link ManagedSpan}.
      *
      * @return The current ManagedSpan or the managed <code>NoopSpan</code> if there is no managed span.
      * @see SpanManager#manage(Span)

--- a/src/main/java/io/opentracing/contrib/spanmanager/SpanManager.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/SpanManager.java
@@ -48,7 +48,7 @@ public interface SpanManager {
     /**
      * Return the current {@link ManagedSpan}.
      *
-     * @return The current ManagedSpan or null if there is no managed span.
+     * @return The current ManagedSpan
      * @see SpanManager#manage(Span)
      */
     ManagedSpan current();
@@ -76,7 +76,7 @@ public interface SpanManager {
         /**
          * The span that became the managed span at some point.
          *
-         * @return The contained span to be released.
+         * @return The contained span to be released, or null if no span is being managed
          */
         Span getSpan();
 

--- a/src/main/java/io/opentracing/contrib/spanmanager/SpanManager.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/SpanManager.java
@@ -48,7 +48,7 @@ public interface SpanManager {
     /**
      * Return the current {@link ManagedSpan}.
      *
-     * @return The current ManagedSpan or the managed <code>NoopSpan</code> if there is no managed span.
+     * @return The current ManagedSpan or null if there is no managed span.
      * @see SpanManager#manage(Span)
      */
     ManagedSpan current();

--- a/src/main/java/io/opentracing/contrib/spanmanager/SpanManager.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/SpanManager.java
@@ -29,10 +29,10 @@ public interface SpanManager {
     /**
      * Return the currently-managed {@link Span}.
      *
-     * @return The current Span, or the managed <code>NoopSpan</code> if there is no managed span.
+     * @return The current Span, or the <code>NoopSpan</code> if there is no managed span.
      * @see SpanManager#manage(Span)
      */
-    ManagedSpan currentSpan();
+    Span currentSpan();
 
     /**
      * Makes span the <em>current span</em> within the running process.
@@ -43,6 +43,14 @@ public interface SpanManager {
      * @see ManagedSpan#release()
      */
     ManagedSpan manage(Span span);
+
+    /**
+     * Return the current <code>ManagedSpan</code>.
+     *
+     * @return The current ManagedSpan
+     * @see SpanManager#manage(Span)
+     */
+    ManagedSpan current();
 
     /**
      * Unconditional cleanup of all managed spans including any parents.

--- a/src/main/java/io/opentracing/contrib/spanmanager/SpanManager.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/SpanManager.java
@@ -31,6 +31,7 @@ public interface SpanManager {
      *
      * @return The current Span, or the <code>NoopSpan</code> if there is no managed span.
      * @see SpanManager#manage(Span)
+     * @deprecated Use SpanManager#current() instead
      */
     Span currentSpan();
 
@@ -45,9 +46,9 @@ public interface SpanManager {
     ManagedSpan manage(Span span);
 
     /**
-     * Return the current <code>ManagedSpan</code>.
+     * Return the current <{@link ManagedSpan}.
      *
-     * @return The current ManagedSpan
+     * @return The current ManagedSpan or the managed <code>NoopSpan</code> if there is no managed span.
      * @see SpanManager#manage(Span)
      */
     ManagedSpan current();

--- a/src/main/java/io/opentracing/contrib/spanmanager/SpanManager.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/SpanManager.java
@@ -29,10 +29,10 @@ public interface SpanManager {
     /**
      * Return the currently-managed {@link Span}.
      *
-     * @return The current Span, or the <code>NoopSpan</code> if there is no managed span.
+     * @return The current Span, or the managed <code>NoopSpan</code> if there is no managed span.
      * @see SpanManager#manage(Span)
      */
-    Span currentSpan();
+    ManagedSpan currentSpan();
 
     /**
      * Makes span the <em>current span</em> within the running process.

--- a/src/main/java/io/opentracing/contrib/spanmanager/concurrent/SpanPropagatingExecutorService.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/concurrent/SpanPropagatingExecutorService.java
@@ -80,44 +80,44 @@ public class SpanPropagatingExecutorService implements ExecutorService {
 
     @Override
     public void execute(Runnable command) {
-        delegate.execute(runnableWithCurrentSpan(command, spanManager.currentSpan()));
+        delegate.execute(runnableWithCurrentSpan(command, spanManager.currentSpan().getSpan()));
     }
 
     @Override
     public Future<?> submit(Runnable task) {
-        return delegate.submit(runnableWithCurrentSpan(task, spanManager.currentSpan()));
+        return delegate.submit(runnableWithCurrentSpan(task, spanManager.currentSpan().getSpan()));
     }
 
     @Override
     public <T> Future<T> submit(Runnable task, T result) {
-        return delegate.submit(runnableWithCurrentSpan(task, spanManager.currentSpan()), result);
+        return delegate.submit(runnableWithCurrentSpan(task, spanManager.currentSpan().getSpan()), result);
     }
 
     @Override
     public <T> Future<T> submit(Callable<T> task) {
-        return delegate.submit(callableWithCurrentSpan(task, spanManager.currentSpan()));
+        return delegate.submit(callableWithCurrentSpan(task, spanManager.currentSpan().getSpan()));
     }
 
     @Override
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
-        return delegate.invokeAll(tasksWithCurrentSpan(tasks, spanManager.currentSpan()));
+        return delegate.invokeAll(tasksWithCurrentSpan(tasks, spanManager.currentSpan().getSpan()));
     }
 
     @Override
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
             throws InterruptedException {
-        return delegate.invokeAll(tasksWithCurrentSpan(tasks, spanManager.currentSpan()), timeout, unit);
+        return delegate.invokeAll(tasksWithCurrentSpan(tasks, spanManager.currentSpan().getSpan()), timeout, unit);
     }
 
     @Override
     public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
-        return delegate.invokeAny(tasksWithCurrentSpan(tasks, spanManager.currentSpan()));
+        return delegate.invokeAny(tasksWithCurrentSpan(tasks, spanManager.currentSpan().getSpan()));
     }
 
     @Override
     public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
             throws InterruptedException, ExecutionException, TimeoutException {
-        return delegate.invokeAny(tasksWithCurrentSpan(tasks, spanManager.currentSpan()), timeout, unit);
+        return delegate.invokeAny(tasksWithCurrentSpan(tasks, spanManager.currentSpan().getSpan()), timeout, unit);
     }
 
     @Override

--- a/src/main/java/io/opentracing/contrib/spanmanager/concurrent/SpanPropagatingExecutorService.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/concurrent/SpanPropagatingExecutorService.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.concurrent.*;
 
 /**
- * Propagates the {@link SpanManager#currentSpan() current span} from the caller
+ * Propagates the {@link SpanManager#current() current managed span} from the caller
  * into each call that is executed.
  * <p>
  * <em>Note:</em> The current span is merely propagated.
@@ -34,7 +34,7 @@ public class SpanPropagatingExecutorService implements ExecutorService {
     private final SpanManager spanManager;
 
     /**
-     * Wraps the delegate ExecutorService to propagate the {@link SpanManager#currentSpan() current span}
+     * Wraps the delegate ExecutorService to propagate the {@link SpanManager#current() managed span}
      * of callers into the executed calls, using the specified {@link SpanManager}.
      *
      * @param delegate    The executorservice to forward calls to.
@@ -48,7 +48,7 @@ public class SpanPropagatingExecutorService implements ExecutorService {
     }
 
     /**
-     * Propagates the {@link SpanManager#currentSpan() custom current span} into the runnable
+     * Propagates the {@link SpanManager#current() custom current span} into the runnable
      * and performs cleanup afterwards.
      * <p>
      * <em>Note:</em> The <code>customCurrentSpan</code> is merely propagated.
@@ -63,7 +63,7 @@ public class SpanPropagatingExecutorService implements ExecutorService {
     }
 
     /**
-     * Propagates the {@link SpanManager#currentSpan() custom current span} into the callable
+     * Propagates the {@link SpanManager#current() custom current span} into the callable
      * and performs cleanup afterwards.
      * <p>
      * <em>Note:</em> The <code>customCurrentSpan</code> is merely propagated.
@@ -80,44 +80,44 @@ public class SpanPropagatingExecutorService implements ExecutorService {
 
     @Override
     public void execute(Runnable command) {
-        delegate.execute(runnableWithCurrentSpan(command, spanManager.currentSpan()));
+        delegate.execute(runnableWithCurrentSpan(command, spanManager.current().getSpan()));
     }
 
     @Override
     public Future<?> submit(Runnable task) {
-        return delegate.submit(runnableWithCurrentSpan(task, spanManager.currentSpan()));
+        return delegate.submit(runnableWithCurrentSpan(task, spanManager.current().getSpan()));
     }
 
     @Override
     public <T> Future<T> submit(Runnable task, T result) {
-        return delegate.submit(runnableWithCurrentSpan(task, spanManager.currentSpan()), result);
+        return delegate.submit(runnableWithCurrentSpan(task, spanManager.current().getSpan()), result);
     }
 
     @Override
     public <T> Future<T> submit(Callable<T> task) {
-        return delegate.submit(callableWithCurrentSpan(task, spanManager.currentSpan()));
+        return delegate.submit(callableWithCurrentSpan(task, spanManager.current().getSpan()));
     }
 
     @Override
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
-        return delegate.invokeAll(tasksWithCurrentSpan(tasks, spanManager.currentSpan()));
+        return delegate.invokeAll(tasksWithCurrentSpan(tasks, spanManager.current().getSpan()));
     }
 
     @Override
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
             throws InterruptedException {
-        return delegate.invokeAll(tasksWithCurrentSpan(tasks, spanManager.currentSpan()), timeout, unit);
+        return delegate.invokeAll(tasksWithCurrentSpan(tasks, spanManager.current().getSpan()), timeout, unit);
     }
 
     @Override
     public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
-        return delegate.invokeAny(tasksWithCurrentSpan(tasks, spanManager.currentSpan()));
+        return delegate.invokeAny(tasksWithCurrentSpan(tasks, spanManager.current().getSpan()));
     }
 
     @Override
     public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
             throws InterruptedException, ExecutionException, TimeoutException {
-        return delegate.invokeAny(tasksWithCurrentSpan(tasks, spanManager.currentSpan()), timeout, unit);
+        return delegate.invokeAny(tasksWithCurrentSpan(tasks, spanManager.current().getSpan()), timeout, unit);
     }
 
     @Override

--- a/src/main/java/io/opentracing/contrib/spanmanager/concurrent/SpanPropagatingExecutorService.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/concurrent/SpanPropagatingExecutorService.java
@@ -15,6 +15,7 @@ package io.opentracing.contrib.spanmanager.concurrent;
 
 import io.opentracing.Span;
 import io.opentracing.contrib.spanmanager.SpanManager;
+import io.opentracing.contrib.spanmanager.SpanManager.ManagedSpan;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -80,44 +81,60 @@ public class SpanPropagatingExecutorService implements ExecutorService {
 
     @Override
     public void execute(Runnable command) {
-        delegate.execute(runnableWithCurrentSpan(command, spanManager.current().getSpan()));
+        ManagedSpan current = spanManager.current();
+        delegate.execute(runnableWithCurrentSpan(command,
+                current != null ? current.getSpan() : null));
     }
 
     @Override
     public Future<?> submit(Runnable task) {
-        return delegate.submit(runnableWithCurrentSpan(task, spanManager.current().getSpan()));
+        ManagedSpan current = spanManager.current();
+        return delegate.submit(runnableWithCurrentSpan(task, 
+                current != null ? current.getSpan() : null));
     }
 
     @Override
     public <T> Future<T> submit(Runnable task, T result) {
-        return delegate.submit(runnableWithCurrentSpan(task, spanManager.current().getSpan()), result);
+        ManagedSpan current = spanManager.current();
+        return delegate.submit(runnableWithCurrentSpan(task,
+                current != null ? current.getSpan() : null), result);
     }
 
     @Override
     public <T> Future<T> submit(Callable<T> task) {
-        return delegate.submit(callableWithCurrentSpan(task, spanManager.current().getSpan()));
+        ManagedSpan current = spanManager.current();
+        return delegate.submit(callableWithCurrentSpan(task,
+                current != null ? current.getSpan() : null));
     }
 
     @Override
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
-        return delegate.invokeAll(tasksWithCurrentSpan(tasks, spanManager.current().getSpan()));
+        ManagedSpan current = spanManager.current();
+        return delegate.invokeAll(tasksWithCurrentSpan(tasks,
+                current != null ? current.getSpan() : null));
     }
 
     @Override
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
             throws InterruptedException {
-        return delegate.invokeAll(tasksWithCurrentSpan(tasks, spanManager.current().getSpan()), timeout, unit);
+        ManagedSpan current = spanManager.current();
+        return delegate.invokeAll(tasksWithCurrentSpan(tasks,
+                current != null ? current.getSpan() : null), timeout, unit);
     }
 
     @Override
     public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
-        return delegate.invokeAny(tasksWithCurrentSpan(tasks, spanManager.current().getSpan()));
+        ManagedSpan current = spanManager.current();
+        return delegate.invokeAny(tasksWithCurrentSpan(tasks,
+                current != null ? current.getSpan() : null));
     }
 
     @Override
     public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
             throws InterruptedException, ExecutionException, TimeoutException {
-        return delegate.invokeAny(tasksWithCurrentSpan(tasks, spanManager.current().getSpan()), timeout, unit);
+        ManagedSpan current = spanManager.current();
+        return delegate.invokeAny(tasksWithCurrentSpan(tasks,
+                current != null ? current.getSpan() : null), timeout, unit);
     }
 
     @Override

--- a/src/main/java/io/opentracing/contrib/spanmanager/concurrent/SpanPropagatingExecutorService.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/concurrent/SpanPropagatingExecutorService.java
@@ -15,7 +15,6 @@ package io.opentracing.contrib.spanmanager.concurrent;
 
 import io.opentracing.Span;
 import io.opentracing.contrib.spanmanager.SpanManager;
-import io.opentracing.contrib.spanmanager.SpanManager.ManagedSpan;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -81,60 +80,44 @@ public class SpanPropagatingExecutorService implements ExecutorService {
 
     @Override
     public void execute(Runnable command) {
-        ManagedSpan current = spanManager.current();
-        delegate.execute(runnableWithCurrentSpan(command,
-                current != null ? current.getSpan() : null));
+        delegate.execute(runnableWithCurrentSpan(command, spanManager.current().getSpan()));
     }
 
     @Override
     public Future<?> submit(Runnable task) {
-        ManagedSpan current = spanManager.current();
-        return delegate.submit(runnableWithCurrentSpan(task, 
-                current != null ? current.getSpan() : null));
+        return delegate.submit(runnableWithCurrentSpan(task, spanManager.current().getSpan()));
     }
 
     @Override
     public <T> Future<T> submit(Runnable task, T result) {
-        ManagedSpan current = spanManager.current();
-        return delegate.submit(runnableWithCurrentSpan(task,
-                current != null ? current.getSpan() : null), result);
+        return delegate.submit(runnableWithCurrentSpan(task, spanManager.current().getSpan()), result);
     }
 
     @Override
     public <T> Future<T> submit(Callable<T> task) {
-        ManagedSpan current = spanManager.current();
-        return delegate.submit(callableWithCurrentSpan(task,
-                current != null ? current.getSpan() : null));
+        return delegate.submit(callableWithCurrentSpan(task, spanManager.current().getSpan()));
     }
 
     @Override
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
-        ManagedSpan current = spanManager.current();
-        return delegate.invokeAll(tasksWithCurrentSpan(tasks,
-                current != null ? current.getSpan() : null));
+        return delegate.invokeAll(tasksWithCurrentSpan(tasks, spanManager.current().getSpan()));
     }
 
     @Override
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
             throws InterruptedException {
-        ManagedSpan current = spanManager.current();
-        return delegate.invokeAll(tasksWithCurrentSpan(tasks,
-                current != null ? current.getSpan() : null), timeout, unit);
+        return delegate.invokeAll(tasksWithCurrentSpan(tasks, spanManager.current().getSpan()), timeout, unit);
     }
 
     @Override
     public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
-        ManagedSpan current = spanManager.current();
-        return delegate.invokeAny(tasksWithCurrentSpan(tasks,
-                current != null ? current.getSpan() : null));
+        return delegate.invokeAny(tasksWithCurrentSpan(tasks, spanManager.current().getSpan()));
     }
 
     @Override
     public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
             throws InterruptedException, ExecutionException, TimeoutException {
-        ManagedSpan current = spanManager.current();
-        return delegate.invokeAny(tasksWithCurrentSpan(tasks,
-                current != null ? current.getSpan() : null), timeout, unit);
+        return delegate.invokeAny(tasksWithCurrentSpan(tasks, spanManager.current().getSpan()), timeout, unit);
     }
 
     @Override

--- a/src/main/java/io/opentracing/contrib/spanmanager/concurrent/SpanPropagatingExecutorService.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/concurrent/SpanPropagatingExecutorService.java
@@ -80,44 +80,44 @@ public class SpanPropagatingExecutorService implements ExecutorService {
 
     @Override
     public void execute(Runnable command) {
-        delegate.execute(runnableWithCurrentSpan(command, spanManager.currentSpan().getSpan()));
+        delegate.execute(runnableWithCurrentSpan(command, spanManager.currentSpan()));
     }
 
     @Override
     public Future<?> submit(Runnable task) {
-        return delegate.submit(runnableWithCurrentSpan(task, spanManager.currentSpan().getSpan()));
+        return delegate.submit(runnableWithCurrentSpan(task, spanManager.currentSpan()));
     }
 
     @Override
     public <T> Future<T> submit(Runnable task, T result) {
-        return delegate.submit(runnableWithCurrentSpan(task, spanManager.currentSpan().getSpan()), result);
+        return delegate.submit(runnableWithCurrentSpan(task, spanManager.currentSpan()), result);
     }
 
     @Override
     public <T> Future<T> submit(Callable<T> task) {
-        return delegate.submit(callableWithCurrentSpan(task, spanManager.currentSpan().getSpan()));
+        return delegate.submit(callableWithCurrentSpan(task, spanManager.currentSpan()));
     }
 
     @Override
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
-        return delegate.invokeAll(tasksWithCurrentSpan(tasks, spanManager.currentSpan().getSpan()));
+        return delegate.invokeAll(tasksWithCurrentSpan(tasks, spanManager.currentSpan()));
     }
 
     @Override
     public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
             throws InterruptedException {
-        return delegate.invokeAll(tasksWithCurrentSpan(tasks, spanManager.currentSpan().getSpan()), timeout, unit);
+        return delegate.invokeAll(tasksWithCurrentSpan(tasks, spanManager.currentSpan()), timeout, unit);
     }
 
     @Override
     public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
-        return delegate.invokeAny(tasksWithCurrentSpan(tasks, spanManager.currentSpan().getSpan()));
+        return delegate.invokeAny(tasksWithCurrentSpan(tasks, spanManager.currentSpan()));
     }
 
     @Override
     public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
             throws InterruptedException, ExecutionException, TimeoutException {
-        return delegate.invokeAny(tasksWithCurrentSpan(tasks, spanManager.currentSpan().getSpan()), timeout, unit);
+        return delegate.invokeAny(tasksWithCurrentSpan(tasks, spanManager.currentSpan()), timeout, unit);
     }
 
     @Override

--- a/src/main/java/io/opentracing/contrib/spanmanager/tracer/ManagedSpanTracer.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/tracer/ManagedSpanTracer.java
@@ -20,7 +20,7 @@ import io.opentracing.contrib.spanmanager.SpanManager;
 import io.opentracing.propagation.Format;
 
 /**
- * Convenience {@link Tracer} that automates managing the {@linkplain SpanManager#currentSpan() current span}:
+ * Convenience {@link Tracer} that automates managing the {@linkplain SpanManager#current() current managed span}:
  * <ol>
  * <li>It is a wrapper that forwards all calls to another {@link Tracer} implementation.</li>
  * <li>{@linkplain Span Spans} created with this tracer are

--- a/src/test/java/io/opentracing/contrib/spanmanager/DefaultSpanManagerTest.java
+++ b/src/test/java/io/opentracing/contrib/spanmanager/DefaultSpanManagerTest.java
@@ -21,6 +21,7 @@ import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 
 public class DefaultSpanManagerTest {
@@ -39,7 +40,7 @@ public class DefaultSpanManagerTest {
         Span span2 = mock(Span.class);
         Span span3 = mock(Span.class);
 
-        assertThat("empty stack", manager.current().getSpan(), is(instanceOf(NoopSpan.class)));
+        assertNull("empty stack", manager.current());
 
         ManagedSpan managed1 = manager.manage(span1);
         assertThat("pushed span1", manager.current().getSpan(), is(sameInstance(span1)));
@@ -57,7 +58,7 @@ public class DefaultSpanManagerTest {
         assertThat("popped span2", manager.current().getSpan(), is(sameInstance(span1)));
 
         managed1.release();
-        assertThat("popped span1", manager.current().getSpan(), is(instanceOf(NoopSpan.class)));
+        assertNull("popped span1", manager.current());
     }
 
     @Test
@@ -65,7 +66,7 @@ public class DefaultSpanManagerTest {
         Span span1 = mock(Span.class);
         Span span2 = mock(Span.class);
 
-        assertThat("empty stack", manager.current().getSpan(), is(instanceOf(NoopSpan.class)));
+        assertNull("empty stack", manager.current());
 
         ManagedSpan managed1 = manager.manage(span1);
         assertThat("pushed span1", manager.current().getSpan(), is(sameInstance(span1)));
@@ -81,7 +82,7 @@ public class DefaultSpanManagerTest {
         managed2.release();
         managed1.release();
         managed2.release();
-        assertThat("popped span1", manager.current().getSpan(), is(instanceOf(NoopSpan.class)));
+        assertNull("popped span1", manager.current());
     }
 
 
@@ -91,25 +92,25 @@ public class DefaultSpanManagerTest {
         Span span2 = null;
         Span span3 = mock(Span.class);
 
-        assertThat("empty stack", manager.current().getSpan(), is(instanceOf(NoopSpan.class)));
+        assertNull("empty stack", manager.current());
 
         ManagedSpan managed1 = manager.manage(span1);
         assertThat("pushed span1", manager.current().getSpan(), is(sameInstance(span1)));
 
         ManagedSpan managed2 = manager.manage(span2);
-        assertThat("pushed span2", manager.current().getSpan(), is(instanceOf(NoopSpan.class)));
+        assertNull("pushed span2", manager.current().getSpan());
 
         ManagedSpan managed3 = manager.manage(span3);
         assertThat("pushed span3", manager.current().getSpan(), is(sameInstance(span3)));
 
         managed3.release();
-        assertThat("popped span3", manager.current().getSpan(), is(instanceOf(NoopSpan.class)));
+        assertNull("popped span3", manager.current().getSpan());
 
         managed2.release();
         assertThat("popped span2", manager.current().getSpan(), is(sameInstance(span1)));
 
         managed1.release();
-        assertThat("popped span1", manager.current().getSpan(), is(instanceOf(NoopSpan.class)));
+        assertNull("popped span1", manager.current());
     }
 
     @Test
@@ -118,7 +119,7 @@ public class DefaultSpanManagerTest {
         Span span2 = mock(Span.class);
         Span span3 = mock(Span.class);
 
-        assertThat("empty stack", manager.current().getSpan(), is(instanceOf(NoopSpan.class)));
+        assertNull("empty stack", manager.current());
 
         ManagedSpan managed1 = manager.manage(span1);
         assertThat("pushed span1", manager.current().getSpan(), is(sameInstance(span1)));
@@ -137,7 +138,7 @@ public class DefaultSpanManagerTest {
         assertThat("skipped span2 (already-released)", manager.current().getSpan(), is(sameInstance(span1)));
 
         managed1.release();
-        assertThat("popped span1", manager.current().getSpan(), is(instanceOf(NoopSpan.class)));
+        assertNull("popped span1", manager.current());
     }
 
     /**
@@ -153,7 +154,7 @@ public class DefaultSpanManagerTest {
         Span span2 = mock(Span.class);
         Span span3 = mock(Span.class);
 
-        assertThat("empty stack", manager.current().getSpan(), is(instanceOf(NoopSpan.class)));
+        assertNull("empty stack", manager.current());
 
         ManagedSpan managed1 = manager.manage(span1);
         assertThat("pushed span1", manager.current().getSpan(), is(sameInstance(span1)));
@@ -186,23 +187,20 @@ public class DefaultSpanManagerTest {
         assertThat("popped span2+3", manager.current().getSpan(), is(sameInstance(span1)));
 
         managed1.release();
-        assertThat("popped span1", manager.current().getSpan(), is(instanceOf(NoopSpan.class)));
+        assertNull("popped span1", manager.current());
     }
 
     @Test
     public void testExplicitRelease() {
         Span span1 = mock(Span.class);
 
-        assertThat("empty stack", manager.current().getSpan(), is(instanceOf(NoopSpan.class)));
+        assertNull("empty stack", manager.current());
 
         manager.manage(span1);
         assertThat("pushed span1", manager.current().getSpan(), is(sameInstance(span1)));
 
         manager.current().release();
-        assertThat("popped span1", manager.current().getSpan(), is(instanceOf(NoopSpan.class)));
-
-        // Try releasing - should not have any effect
-        manager.current().release();
+        assertNull("popped span1", manager.current());
     }
 
 }

--- a/src/test/java/io/opentracing/contrib/spanmanager/DefaultSpanManagerTest.java
+++ b/src/test/java/io/opentracing/contrib/spanmanager/DefaultSpanManagerTest.java
@@ -40,7 +40,7 @@ public class DefaultSpanManagerTest {
         Span span2 = mock(Span.class);
         Span span3 = mock(Span.class);
 
-        assertNull("empty stack", manager.current());
+        assertNull("empty stack", manager.current().getSpan());
 
         ManagedSpan managed1 = manager.manage(span1);
         assertThat("pushed span1", manager.current().getSpan(), is(sameInstance(span1)));
@@ -58,7 +58,7 @@ public class DefaultSpanManagerTest {
         assertThat("popped span2", manager.current().getSpan(), is(sameInstance(span1)));
 
         managed1.release();
-        assertNull("popped span1", manager.current());
+        assertNull("popped span1", manager.current().getSpan());
     }
 
     @Test
@@ -66,7 +66,7 @@ public class DefaultSpanManagerTest {
         Span span1 = mock(Span.class);
         Span span2 = mock(Span.class);
 
-        assertNull("empty stack", manager.current());
+        assertNull("empty stack", manager.current().getSpan());
 
         ManagedSpan managed1 = manager.manage(span1);
         assertThat("pushed span1", manager.current().getSpan(), is(sameInstance(span1)));
@@ -82,7 +82,7 @@ public class DefaultSpanManagerTest {
         managed2.release();
         managed1.release();
         managed2.release();
-        assertNull("popped span1", manager.current());
+        assertNull("popped span1", manager.current().getSpan());
     }
 
 
@@ -92,7 +92,7 @@ public class DefaultSpanManagerTest {
         Span span2 = null;
         Span span3 = mock(Span.class);
 
-        assertNull("empty stack", manager.current());
+        assertNull("empty stack", manager.current().getSpan());
 
         ManagedSpan managed1 = manager.manage(span1);
         assertThat("pushed span1", manager.current().getSpan(), is(sameInstance(span1)));
@@ -110,7 +110,7 @@ public class DefaultSpanManagerTest {
         assertThat("popped span2", manager.current().getSpan(), is(sameInstance(span1)));
 
         managed1.release();
-        assertNull("popped span1", manager.current());
+        assertNull("popped span1", manager.current().getSpan());
     }
 
     @Test
@@ -119,7 +119,7 @@ public class DefaultSpanManagerTest {
         Span span2 = mock(Span.class);
         Span span3 = mock(Span.class);
 
-        assertNull("empty stack", manager.current());
+        assertNull("empty stack", manager.current().getSpan());
 
         ManagedSpan managed1 = manager.manage(span1);
         assertThat("pushed span1", manager.current().getSpan(), is(sameInstance(span1)));
@@ -138,7 +138,7 @@ public class DefaultSpanManagerTest {
         assertThat("skipped span2 (already-released)", manager.current().getSpan(), is(sameInstance(span1)));
 
         managed1.release();
-        assertNull("popped span1", manager.current());
+        assertNull("popped span1", manager.current().getSpan());
     }
 
     /**
@@ -154,7 +154,7 @@ public class DefaultSpanManagerTest {
         Span span2 = mock(Span.class);
         Span span3 = mock(Span.class);
 
-        assertNull("empty stack", manager.current());
+        assertNull("empty stack", manager.current().getSpan());
 
         ManagedSpan managed1 = manager.manage(span1);
         assertThat("pushed span1", manager.current().getSpan(), is(sameInstance(span1)));
@@ -187,20 +187,23 @@ public class DefaultSpanManagerTest {
         assertThat("popped span2+3", manager.current().getSpan(), is(sameInstance(span1)));
 
         managed1.release();
-        assertNull("popped span1", manager.current());
+        assertNull("popped span1", manager.current().getSpan());
     }
 
     @Test
     public void testExplicitRelease() {
         Span span1 = mock(Span.class);
 
-        assertNull("empty stack", manager.current());
+        assertNull("empty stack", manager.current().getSpan());
 
         manager.manage(span1);
         assertThat("pushed span1", manager.current().getSpan(), is(sameInstance(span1)));
 
         manager.current().release();
-        assertNull("popped span1", manager.current());
+        assertNull("popped span1", manager.current().getSpan());
+
+        // Try releasing - should not have any effect
+        manager.current().release();
     }
 
 }

--- a/src/test/java/io/opentracing/contrib/spanmanager/DefaultSpanManagerTest.java
+++ b/src/test/java/io/opentracing/contrib/spanmanager/DefaultSpanManagerTest.java
@@ -39,25 +39,25 @@ public class DefaultSpanManagerTest {
         Span span2 = mock(Span.class);
         Span span3 = mock(Span.class);
 
-        assertThat("empty stack", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("empty stack", manager.currentSpan().getSpan(), is(instanceOf(NoopSpan.class)));
 
         ManagedSpan managed1 = manager.manage(span1);
-        assertThat("pushed span1", manager.currentSpan(), is(sameInstance(span1)));
+        assertThat("pushed span1", manager.currentSpan().getSpan(), is(sameInstance(span1)));
 
         ManagedSpan managed2 = manager.manage(span2);
-        assertThat("pushed span2", manager.currentSpan(), is(sameInstance(span2)));
+        assertThat("pushed span2", manager.currentSpan().getSpan(), is(sameInstance(span2)));
 
         ManagedSpan managed3 = manager.manage(span3);
-        assertThat("pushed span3", manager.currentSpan(), is(sameInstance(span3)));
+        assertThat("pushed span3", manager.currentSpan().getSpan(), is(sameInstance(span3)));
 
         managed3.release();
-        assertThat("popped span3", manager.currentSpan(), is(sameInstance(span2)));
+        assertThat("popped span3", manager.currentSpan().getSpan(), is(sameInstance(span2)));
 
         managed2.release();
-        assertThat("popped span2", manager.currentSpan(), is(sameInstance(span1)));
+        assertThat("popped span2", manager.currentSpan().getSpan(), is(sameInstance(span1)));
 
         managed1.release();
-        assertThat("popped span1", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("popped span1", manager.currentSpan().getSpan(), is(instanceOf(NoopSpan.class)));
     }
 
     @Test
@@ -65,23 +65,23 @@ public class DefaultSpanManagerTest {
         Span span1 = mock(Span.class);
         Span span2 = mock(Span.class);
 
-        assertThat("empty stack", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("empty stack", manager.currentSpan().getSpan(), is(instanceOf(NoopSpan.class)));
 
         ManagedSpan managed1 = manager.manage(span1);
-        assertThat("pushed span1", manager.currentSpan(), is(sameInstance(span1)));
+        assertThat("pushed span1", manager.currentSpan().getSpan(), is(sameInstance(span1)));
 
         ManagedSpan managed2 = manager.manage(span2);
-        assertThat("pushed span2", manager.currentSpan(), is(sameInstance(span2)));
+        assertThat("pushed span2", manager.currentSpan().getSpan(), is(sameInstance(span2)));
 
         managed2.release();
         managed2.release();
-        assertThat("popped span2", manager.currentSpan(), is(sameInstance(span1)));
+        assertThat("popped span2", manager.currentSpan().getSpan(), is(sameInstance(span1)));
 
         managed1.release();
         managed2.release();
         managed1.release();
         managed2.release();
-        assertThat("popped span1", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("popped span1", manager.currentSpan().getSpan(), is(instanceOf(NoopSpan.class)));
     }
 
 
@@ -91,25 +91,25 @@ public class DefaultSpanManagerTest {
         Span span2 = null;
         Span span3 = mock(Span.class);
 
-        assertThat("empty stack", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("empty stack", manager.currentSpan().getSpan(), is(instanceOf(NoopSpan.class)));
 
         ManagedSpan managed1 = manager.manage(span1);
-        assertThat("pushed span1", manager.currentSpan(), is(sameInstance(span1)));
+        assertThat("pushed span1", manager.currentSpan().getSpan(), is(sameInstance(span1)));
 
         ManagedSpan managed2 = manager.manage(span2);
-        assertThat("pushed span2", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("pushed span2", manager.currentSpan().getSpan(), is(instanceOf(NoopSpan.class)));
 
         ManagedSpan managed3 = manager.manage(span3);
-        assertThat("pushed span3", manager.currentSpan(), is(sameInstance(span3)));
+        assertThat("pushed span3", manager.currentSpan().getSpan(), is(sameInstance(span3)));
 
         managed3.release();
-        assertThat("popped span3", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("popped span3", manager.currentSpan().getSpan(), is(instanceOf(NoopSpan.class)));
 
         managed2.release();
-        assertThat("popped span2", manager.currentSpan(), is(sameInstance(span1)));
+        assertThat("popped span2", manager.currentSpan().getSpan(), is(sameInstance(span1)));
 
         managed1.release();
-        assertThat("popped span1", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("popped span1", manager.currentSpan().getSpan(), is(instanceOf(NoopSpan.class)));
     }
 
     @Test
@@ -118,26 +118,26 @@ public class DefaultSpanManagerTest {
         Span span2 = mock(Span.class);
         Span span3 = mock(Span.class);
 
-        assertThat("empty stack", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("empty stack", manager.currentSpan().getSpan(), is(instanceOf(NoopSpan.class)));
 
         ManagedSpan managed1 = manager.manage(span1);
-        assertThat("pushed span1", manager.currentSpan(), is(sameInstance(span1)));
+        assertThat("pushed span1", manager.currentSpan().getSpan(), is(sameInstance(span1)));
 
         ManagedSpan managed2 = manager.manage(span2);
-        assertThat("pushed span2", manager.currentSpan(), is(sameInstance(span2)));
+        assertThat("pushed span2", manager.currentSpan().getSpan(), is(sameInstance(span2)));
 
         ManagedSpan managed3 = manager.manage(span3);
-        assertThat("pushed span3", manager.currentSpan(), is(sameInstance(span3)));
+        assertThat("pushed span3", manager.currentSpan().getSpan(), is(sameInstance(span3)));
 
         // Pop2: Span1 -> Span2(X) -> Span3  :  currentSpan stays Span3
         managed2.release();
-        assertThat("released span2", manager.currentSpan(), is(sameInstance(span3)));
+        assertThat("released span2", manager.currentSpan().getSpan(), is(sameInstance(span3)));
 
         managed3.release();
-        assertThat("skipped span2 (already-released)", manager.currentSpan(), is(sameInstance(span1)));
+        assertThat("skipped span2 (already-released)", manager.currentSpan().getSpan(), is(sameInstance(span1)));
 
         managed1.release();
-        assertThat("popped span1", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("popped span1", manager.currentSpan().getSpan(), is(instanceOf(NoopSpan.class)));
     }
 
     /**
@@ -153,16 +153,16 @@ public class DefaultSpanManagerTest {
         Span span2 = mock(Span.class);
         Span span3 = mock(Span.class);
 
-        assertThat("empty stack", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("empty stack", manager.currentSpan().getSpan(), is(instanceOf(NoopSpan.class)));
 
         ManagedSpan managed1 = manager.manage(span1);
-        assertThat("pushed span1", manager.currentSpan(), is(sameInstance(span1)));
+        assertThat("pushed span1", manager.currentSpan().getSpan(), is(sameInstance(span1)));
 
         final ManagedSpan managed2 = manager.manage(span2);
-        assertThat("pushed span2", manager.currentSpan(), is(sameInstance(span2)));
+        assertThat("pushed span2", manager.currentSpan().getSpan(), is(sameInstance(span2)));
 
         ManagedSpan managed3 = manager.manage(span3);
-        assertThat("pushed span3", manager.currentSpan(), is(sameInstance(span3)));
+        assertThat("pushed span3", manager.currentSpan().getSpan(), is(sameInstance(span3)));
 
         // Schedule 10 threads to release managed2
         Thread[] releasers = new Thread[10];
@@ -183,10 +183,10 @@ public class DefaultSpanManagerTest {
         // Wait for managed2.releases
         for (int i = 0; i < releasers.length; i++) releasers[i].join();
 
-        assertThat("popped span2+3", manager.currentSpan(), is(sameInstance(span1)));
+        assertThat("popped span2+3", manager.currentSpan().getSpan(), is(sameInstance(span1)));
 
         managed1.release();
-        assertThat("popped span1", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("popped span1", manager.currentSpan().getSpan(), is(instanceOf(NoopSpan.class)));
     }
 
 }

--- a/src/test/java/io/opentracing/contrib/spanmanager/DefaultSpanManagerTest.java
+++ b/src/test/java/io/opentracing/contrib/spanmanager/DefaultSpanManagerTest.java
@@ -39,25 +39,25 @@ public class DefaultSpanManagerTest {
         Span span2 = mock(Span.class);
         Span span3 = mock(Span.class);
 
-        assertThat("empty stack", manager.currentSpan().getSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("empty stack", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
 
         ManagedSpan managed1 = manager.manage(span1);
-        assertThat("pushed span1", manager.currentSpan().getSpan(), is(sameInstance(span1)));
+        assertThat("pushed span1", manager.currentSpan(), is(sameInstance(span1)));
 
         ManagedSpan managed2 = manager.manage(span2);
-        assertThat("pushed span2", manager.currentSpan().getSpan(), is(sameInstance(span2)));
+        assertThat("pushed span2", manager.currentSpan(), is(sameInstance(span2)));
 
         ManagedSpan managed3 = manager.manage(span3);
-        assertThat("pushed span3", manager.currentSpan().getSpan(), is(sameInstance(span3)));
+        assertThat("pushed span3", manager.currentSpan(), is(sameInstance(span3)));
 
         managed3.release();
-        assertThat("popped span3", manager.currentSpan().getSpan(), is(sameInstance(span2)));
+        assertThat("popped span3", manager.currentSpan(), is(sameInstance(span2)));
 
         managed2.release();
-        assertThat("popped span2", manager.currentSpan().getSpan(), is(sameInstance(span1)));
+        assertThat("popped span2", manager.currentSpan(), is(sameInstance(span1)));
 
         managed1.release();
-        assertThat("popped span1", manager.currentSpan().getSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("popped span1", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
     }
 
     @Test
@@ -65,23 +65,23 @@ public class DefaultSpanManagerTest {
         Span span1 = mock(Span.class);
         Span span2 = mock(Span.class);
 
-        assertThat("empty stack", manager.currentSpan().getSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("empty stack", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
 
         ManagedSpan managed1 = manager.manage(span1);
-        assertThat("pushed span1", manager.currentSpan().getSpan(), is(sameInstance(span1)));
+        assertThat("pushed span1", manager.currentSpan(), is(sameInstance(span1)));
 
         ManagedSpan managed2 = manager.manage(span2);
-        assertThat("pushed span2", manager.currentSpan().getSpan(), is(sameInstance(span2)));
+        assertThat("pushed span2", manager.currentSpan(), is(sameInstance(span2)));
 
         managed2.release();
         managed2.release();
-        assertThat("popped span2", manager.currentSpan().getSpan(), is(sameInstance(span1)));
+        assertThat("popped span2", manager.currentSpan(), is(sameInstance(span1)));
 
         managed1.release();
         managed2.release();
         managed1.release();
         managed2.release();
-        assertThat("popped span1", manager.currentSpan().getSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("popped span1", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
     }
 
 
@@ -91,25 +91,25 @@ public class DefaultSpanManagerTest {
         Span span2 = null;
         Span span3 = mock(Span.class);
 
-        assertThat("empty stack", manager.currentSpan().getSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("empty stack", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
 
         ManagedSpan managed1 = manager.manage(span1);
-        assertThat("pushed span1", manager.currentSpan().getSpan(), is(sameInstance(span1)));
+        assertThat("pushed span1", manager.currentSpan(), is(sameInstance(span1)));
 
         ManagedSpan managed2 = manager.manage(span2);
-        assertThat("pushed span2", manager.currentSpan().getSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("pushed span2", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
 
         ManagedSpan managed3 = manager.manage(span3);
-        assertThat("pushed span3", manager.currentSpan().getSpan(), is(sameInstance(span3)));
+        assertThat("pushed span3", manager.currentSpan(), is(sameInstance(span3)));
 
         managed3.release();
-        assertThat("popped span3", manager.currentSpan().getSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("popped span3", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
 
         managed2.release();
-        assertThat("popped span2", manager.currentSpan().getSpan(), is(sameInstance(span1)));
+        assertThat("popped span2", manager.currentSpan(), is(sameInstance(span1)));
 
         managed1.release();
-        assertThat("popped span1", manager.currentSpan().getSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("popped span1", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
     }
 
     @Test
@@ -118,26 +118,26 @@ public class DefaultSpanManagerTest {
         Span span2 = mock(Span.class);
         Span span3 = mock(Span.class);
 
-        assertThat("empty stack", manager.currentSpan().getSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("empty stack", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
 
         ManagedSpan managed1 = manager.manage(span1);
-        assertThat("pushed span1", manager.currentSpan().getSpan(), is(sameInstance(span1)));
+        assertThat("pushed span1", manager.currentSpan(), is(sameInstance(span1)));
 
         ManagedSpan managed2 = manager.manage(span2);
-        assertThat("pushed span2", manager.currentSpan().getSpan(), is(sameInstance(span2)));
+        assertThat("pushed span2", manager.currentSpan(), is(sameInstance(span2)));
 
         ManagedSpan managed3 = manager.manage(span3);
-        assertThat("pushed span3", manager.currentSpan().getSpan(), is(sameInstance(span3)));
+        assertThat("pushed span3", manager.currentSpan(), is(sameInstance(span3)));
 
         // Pop2: Span1 -> Span2(X) -> Span3  :  currentSpan stays Span3
         managed2.release();
-        assertThat("released span2", manager.currentSpan().getSpan(), is(sameInstance(span3)));
+        assertThat("released span2", manager.currentSpan(), is(sameInstance(span3)));
 
         managed3.release();
-        assertThat("skipped span2 (already-released)", manager.currentSpan().getSpan(), is(sameInstance(span1)));
+        assertThat("skipped span2 (already-released)", manager.currentSpan(), is(sameInstance(span1)));
 
         managed1.release();
-        assertThat("popped span1", manager.currentSpan().getSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("popped span1", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
     }
 
     /**
@@ -153,16 +153,16 @@ public class DefaultSpanManagerTest {
         Span span2 = mock(Span.class);
         Span span3 = mock(Span.class);
 
-        assertThat("empty stack", manager.currentSpan().getSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("empty stack", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
 
         ManagedSpan managed1 = manager.manage(span1);
-        assertThat("pushed span1", manager.currentSpan().getSpan(), is(sameInstance(span1)));
+        assertThat("pushed span1", manager.currentSpan(), is(sameInstance(span1)));
 
         final ManagedSpan managed2 = manager.manage(span2);
-        assertThat("pushed span2", manager.currentSpan().getSpan(), is(sameInstance(span2)));
+        assertThat("pushed span2", manager.currentSpan(), is(sameInstance(span2)));
 
         ManagedSpan managed3 = manager.manage(span3);
-        assertThat("pushed span3", manager.currentSpan().getSpan(), is(sameInstance(span3)));
+        assertThat("pushed span3", manager.currentSpan(), is(sameInstance(span3)));
 
         // Schedule 10 threads to release managed2
         Thread[] releasers = new Thread[10];
@@ -183,10 +183,26 @@ public class DefaultSpanManagerTest {
         // Wait for managed2.releases
         for (int i = 0; i < releasers.length; i++) releasers[i].join();
 
-        assertThat("popped span2+3", manager.currentSpan().getSpan(), is(sameInstance(span1)));
+        assertThat("popped span2+3", manager.currentSpan(), is(sameInstance(span1)));
 
         managed1.release();
-        assertThat("popped span1", manager.currentSpan().getSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("popped span1", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+    }
+
+    @Test
+    public void testExplicitRelease() {
+        Span span1 = mock(Span.class);
+
+        assertThat("empty stack", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+
+        manager.manage(span1);
+        assertThat("pushed span1", manager.currentSpan(), is(sameInstance(span1)));
+
+        manager.current().release();
+        assertThat("popped span1", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+
+        // Try releasing - should not have any effect
+        manager.current().release();
     }
 
 }

--- a/src/test/java/io/opentracing/contrib/spanmanager/DefaultSpanManagerTest.java
+++ b/src/test/java/io/opentracing/contrib/spanmanager/DefaultSpanManagerTest.java
@@ -39,25 +39,25 @@ public class DefaultSpanManagerTest {
         Span span2 = mock(Span.class);
         Span span3 = mock(Span.class);
 
-        assertThat("empty stack", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("empty stack", manager.current().getSpan(), is(instanceOf(NoopSpan.class)));
 
         ManagedSpan managed1 = manager.manage(span1);
-        assertThat("pushed span1", manager.currentSpan(), is(sameInstance(span1)));
+        assertThat("pushed span1", manager.current().getSpan(), is(sameInstance(span1)));
 
         ManagedSpan managed2 = manager.manage(span2);
-        assertThat("pushed span2", manager.currentSpan(), is(sameInstance(span2)));
+        assertThat("pushed span2", manager.current().getSpan(), is(sameInstance(span2)));
 
         ManagedSpan managed3 = manager.manage(span3);
-        assertThat("pushed span3", manager.currentSpan(), is(sameInstance(span3)));
+        assertThat("pushed span3", manager.current().getSpan(), is(sameInstance(span3)));
 
         managed3.release();
-        assertThat("popped span3", manager.currentSpan(), is(sameInstance(span2)));
+        assertThat("popped span3", manager.current().getSpan(), is(sameInstance(span2)));
 
         managed2.release();
-        assertThat("popped span2", manager.currentSpan(), is(sameInstance(span1)));
+        assertThat("popped span2", manager.current().getSpan(), is(sameInstance(span1)));
 
         managed1.release();
-        assertThat("popped span1", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("popped span1", manager.current().getSpan(), is(instanceOf(NoopSpan.class)));
     }
 
     @Test
@@ -65,23 +65,23 @@ public class DefaultSpanManagerTest {
         Span span1 = mock(Span.class);
         Span span2 = mock(Span.class);
 
-        assertThat("empty stack", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("empty stack", manager.current().getSpan(), is(instanceOf(NoopSpan.class)));
 
         ManagedSpan managed1 = manager.manage(span1);
-        assertThat("pushed span1", manager.currentSpan(), is(sameInstance(span1)));
+        assertThat("pushed span1", manager.current().getSpan(), is(sameInstance(span1)));
 
         ManagedSpan managed2 = manager.manage(span2);
-        assertThat("pushed span2", manager.currentSpan(), is(sameInstance(span2)));
+        assertThat("pushed span2", manager.current().getSpan(), is(sameInstance(span2)));
 
         managed2.release();
         managed2.release();
-        assertThat("popped span2", manager.currentSpan(), is(sameInstance(span1)));
+        assertThat("popped span2", manager.current().getSpan(), is(sameInstance(span1)));
 
         managed1.release();
         managed2.release();
         managed1.release();
         managed2.release();
-        assertThat("popped span1", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("popped span1", manager.current().getSpan(), is(instanceOf(NoopSpan.class)));
     }
 
 
@@ -91,25 +91,25 @@ public class DefaultSpanManagerTest {
         Span span2 = null;
         Span span3 = mock(Span.class);
 
-        assertThat("empty stack", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("empty stack", manager.current().getSpan(), is(instanceOf(NoopSpan.class)));
 
         ManagedSpan managed1 = manager.manage(span1);
-        assertThat("pushed span1", manager.currentSpan(), is(sameInstance(span1)));
+        assertThat("pushed span1", manager.current().getSpan(), is(sameInstance(span1)));
 
         ManagedSpan managed2 = manager.manage(span2);
-        assertThat("pushed span2", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("pushed span2", manager.current().getSpan(), is(instanceOf(NoopSpan.class)));
 
         ManagedSpan managed3 = manager.manage(span3);
-        assertThat("pushed span3", manager.currentSpan(), is(sameInstance(span3)));
+        assertThat("pushed span3", manager.current().getSpan(), is(sameInstance(span3)));
 
         managed3.release();
-        assertThat("popped span3", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("popped span3", manager.current().getSpan(), is(instanceOf(NoopSpan.class)));
 
         managed2.release();
-        assertThat("popped span2", manager.currentSpan(), is(sameInstance(span1)));
+        assertThat("popped span2", manager.current().getSpan(), is(sameInstance(span1)));
 
         managed1.release();
-        assertThat("popped span1", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("popped span1", manager.current().getSpan(), is(instanceOf(NoopSpan.class)));
     }
 
     @Test
@@ -118,26 +118,26 @@ public class DefaultSpanManagerTest {
         Span span2 = mock(Span.class);
         Span span3 = mock(Span.class);
 
-        assertThat("empty stack", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("empty stack", manager.current().getSpan(), is(instanceOf(NoopSpan.class)));
 
         ManagedSpan managed1 = manager.manage(span1);
-        assertThat("pushed span1", manager.currentSpan(), is(sameInstance(span1)));
+        assertThat("pushed span1", manager.current().getSpan(), is(sameInstance(span1)));
 
         ManagedSpan managed2 = manager.manage(span2);
-        assertThat("pushed span2", manager.currentSpan(), is(sameInstance(span2)));
+        assertThat("pushed span2", manager.current().getSpan(), is(sameInstance(span2)));
 
         ManagedSpan managed3 = manager.manage(span3);
-        assertThat("pushed span3", manager.currentSpan(), is(sameInstance(span3)));
+        assertThat("pushed span3", manager.current().getSpan(), is(sameInstance(span3)));
 
         // Pop2: Span1 -> Span2(X) -> Span3  :  currentSpan stays Span3
         managed2.release();
-        assertThat("released span2", manager.currentSpan(), is(sameInstance(span3)));
+        assertThat("released span2", manager.current().getSpan(), is(sameInstance(span3)));
 
         managed3.release();
-        assertThat("skipped span2 (already-released)", manager.currentSpan(), is(sameInstance(span1)));
+        assertThat("skipped span2 (already-released)", manager.current().getSpan(), is(sameInstance(span1)));
 
         managed1.release();
-        assertThat("popped span1", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("popped span1", manager.current().getSpan(), is(instanceOf(NoopSpan.class)));
     }
 
     /**
@@ -153,16 +153,16 @@ public class DefaultSpanManagerTest {
         Span span2 = mock(Span.class);
         Span span3 = mock(Span.class);
 
-        assertThat("empty stack", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("empty stack", manager.current().getSpan(), is(instanceOf(NoopSpan.class)));
 
         ManagedSpan managed1 = manager.manage(span1);
-        assertThat("pushed span1", manager.currentSpan(), is(sameInstance(span1)));
+        assertThat("pushed span1", manager.current().getSpan(), is(sameInstance(span1)));
 
         final ManagedSpan managed2 = manager.manage(span2);
-        assertThat("pushed span2", manager.currentSpan(), is(sameInstance(span2)));
+        assertThat("pushed span2", manager.current().getSpan(), is(sameInstance(span2)));
 
         ManagedSpan managed3 = manager.manage(span3);
-        assertThat("pushed span3", manager.currentSpan(), is(sameInstance(span3)));
+        assertThat("pushed span3", manager.current().getSpan(), is(sameInstance(span3)));
 
         // Schedule 10 threads to release managed2
         Thread[] releasers = new Thread[10];
@@ -183,23 +183,23 @@ public class DefaultSpanManagerTest {
         // Wait for managed2.releases
         for (int i = 0; i < releasers.length; i++) releasers[i].join();
 
-        assertThat("popped span2+3", manager.currentSpan(), is(sameInstance(span1)));
+        assertThat("popped span2+3", manager.current().getSpan(), is(sameInstance(span1)));
 
         managed1.release();
-        assertThat("popped span1", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("popped span1", manager.current().getSpan(), is(instanceOf(NoopSpan.class)));
     }
 
     @Test
     public void testExplicitRelease() {
         Span span1 = mock(Span.class);
 
-        assertThat("empty stack", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("empty stack", manager.current().getSpan(), is(instanceOf(NoopSpan.class)));
 
         manager.manage(span1);
-        assertThat("pushed span1", manager.currentSpan(), is(sameInstance(span1)));
+        assertThat("pushed span1", manager.current().getSpan(), is(sameInstance(span1)));
 
         manager.current().release();
-        assertThat("popped span1", manager.currentSpan(), is(instanceOf(NoopSpan.class)));
+        assertThat("popped span1", manager.current().getSpan(), is(instanceOf(NoopSpan.class)));
 
         // Try releasing - should not have any effect
         manager.current().release();

--- a/src/test/java/io/opentracing/contrib/spanmanager/concurrent/SpanPropagatingExecutorServiceMockTest.java
+++ b/src/test/java/io/opentracing/contrib/spanmanager/concurrent/SpanPropagatingExecutorServiceMockTest.java
@@ -38,7 +38,6 @@ public class SpanPropagatingExecutorServiceMockTest {
     ExecutorService mockExecutorService;
     SpanManager mockSpanManager;
     Span mockSpan;
-    SpanManager.ManagedSpan mockManagedSpan;
 
     SpanPropagatingExecutorService service;
 
@@ -47,9 +46,7 @@ public class SpanPropagatingExecutorServiceMockTest {
         mockExecutorService = mock(ExecutorService.class);
         mockSpanManager = mock(SpanManager.class);
         mockSpan = mock(Span.class);
-        mockManagedSpan = mock(SpanManager.ManagedSpan.class);
-        when(mockSpanManager.currentSpan()).thenReturn(mockManagedSpan);
-        when(mockManagedSpan.getSpan()).thenReturn(mockSpan);
+        when(mockSpanManager.currentSpan()).thenReturn(mockSpan);
 
         service = new SpanPropagatingExecutorService(mockExecutorService, mockSpanManager);
     }

--- a/src/test/java/io/opentracing/contrib/spanmanager/concurrent/SpanPropagatingExecutorServiceMockTest.java
+++ b/src/test/java/io/opentracing/contrib/spanmanager/concurrent/SpanPropagatingExecutorServiceMockTest.java
@@ -15,6 +15,8 @@ package io.opentracing.contrib.spanmanager.concurrent;
 
 import io.opentracing.Span;
 import io.opentracing.contrib.spanmanager.SpanManager;
+import io.opentracing.contrib.spanmanager.SpanManager.ManagedSpan;
+
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Before;
@@ -38,6 +40,7 @@ public class SpanPropagatingExecutorServiceMockTest {
     ExecutorService mockExecutorService;
     SpanManager mockSpanManager;
     Span mockSpan;
+    ManagedSpan mockManagedSpan;
 
     SpanPropagatingExecutorService service;
 
@@ -46,7 +49,9 @@ public class SpanPropagatingExecutorServiceMockTest {
         mockExecutorService = mock(ExecutorService.class);
         mockSpanManager = mock(SpanManager.class);
         mockSpan = mock(Span.class);
-        when(mockSpanManager.currentSpan()).thenReturn(mockSpan);
+        mockManagedSpan = mock(ManagedSpan.class);
+        when(mockManagedSpan.getSpan()).thenReturn(mockSpan);
+        when(mockSpanManager.current()).thenReturn(mockManagedSpan);
 
         service = new SpanPropagatingExecutorService(mockExecutorService, mockSpanManager);
     }
@@ -62,7 +67,7 @@ public class SpanPropagatingExecutorServiceMockTest {
 
         service.execute(runnable);
 
-        verify(mockSpanManager).currentSpan(); // current span must be propagated
+        verify(mockSpanManager).current(); // current span must be propagated
         verify(mockExecutorService).execute(any(RunnableWithManagedSpan.class)); // into RunnableWithManagedSpan
     }
 
@@ -74,7 +79,7 @@ public class SpanPropagatingExecutorServiceMockTest {
 
         assertThat(service.submit(runnable), is(sameInstance(future)));
 
-        verify(mockSpanManager).currentSpan(); // current span must be propagated
+        verify(mockSpanManager).current(); // current span must be propagated
         verify(mockExecutorService).submit(any(RunnableWithManagedSpan.class)); // into RunnableWithManagedSpan
     }
 
@@ -86,7 +91,7 @@ public class SpanPropagatingExecutorServiceMockTest {
 
         assertThat(service.submit(callable), is(sameInstance(future)));
 
-        verify(mockSpanManager).currentSpan(); // current span must be propagated
+        verify(mockSpanManager).current(); // current span must be propagated
         verify(mockExecutorService).submit(any(CallableWithManagedSpan.class)); // into CallableWithManagedSpan
     }
 
@@ -98,7 +103,7 @@ public class SpanPropagatingExecutorServiceMockTest {
 
         assertThat(service.invokeAll(callables), is(sameInstance(futures)));
 
-        verify(mockSpanManager, times(1)).currentSpan(); // current span must be obtained once
+        verify(mockSpanManager, times(1)).current(); // current span must be obtained once
         verify(mockExecutorService).invokeAll(anyCollection());
     }
 

--- a/src/test/java/io/opentracing/contrib/spanmanager/concurrent/SpanPropagatingExecutorServiceMockTest.java
+++ b/src/test/java/io/opentracing/contrib/spanmanager/concurrent/SpanPropagatingExecutorServiceMockTest.java
@@ -38,6 +38,7 @@ public class SpanPropagatingExecutorServiceMockTest {
     ExecutorService mockExecutorService;
     SpanManager mockSpanManager;
     Span mockSpan;
+    SpanManager.ManagedSpan mockManagedSpan;
 
     SpanPropagatingExecutorService service;
 
@@ -46,7 +47,9 @@ public class SpanPropagatingExecutorServiceMockTest {
         mockExecutorService = mock(ExecutorService.class);
         mockSpanManager = mock(SpanManager.class);
         mockSpan = mock(Span.class);
-        when(mockSpanManager.currentSpan()).thenReturn(mockSpan);
+        mockManagedSpan = mock(SpanManager.ManagedSpan.class);
+        when(mockSpanManager.currentSpan()).thenReturn(mockManagedSpan);
+        when(mockManagedSpan.getSpan()).thenReturn(mockSpan);
 
         service = new SpanPropagatingExecutorService(mockExecutorService, mockSpanManager);
     }

--- a/src/test/java/io/opentracing/contrib/spanmanager/concurrent/SpanPropagatingExecutorServiceTest.java
+++ b/src/test/java/io/opentracing/contrib/spanmanager/concurrent/SpanPropagatingExecutorServiceTest.java
@@ -150,14 +150,14 @@ public class SpanPropagatingExecutorServiceTest {
 
         @Override
         public void run() {
-            span = spanManager.currentSpan();
+            span = spanManager.current().getSpan();
         }
     }
 
     static class CurrentSpanCallable implements Callable<Span> {
         @Override
         public Span call() {
-            return spanManager.currentSpan();
+            return spanManager.current().getSpan();
         }
     }
 

--- a/src/test/java/io/opentracing/contrib/spanmanager/concurrent/SpanPropagatingExecutorServiceTest.java
+++ b/src/test/java/io/opentracing/contrib/spanmanager/concurrent/SpanPropagatingExecutorServiceTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.*;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 
 public class SpanPropagatingExecutorServiceTest {
@@ -129,20 +130,20 @@ public class SpanPropagatingExecutorServiceTest {
         subject.execute(future);
         future.get();
 
-        assertThat("Current span in thread", runnable.span, allOf(notNullValue(), instanceOf(NoopSpan.class)));
+        assertNull("Current span in thread", runnable.span);
     }
 
     @Test
     public void testSubmitRunnableWithoutCurrentSpan() throws ExecutionException, InterruptedException {
         CurrentSpanRunnable runnable = new CurrentSpanRunnable();
         subject.submit(runnable).get(); // submit and block.
-        assertThat("Current span in thread", runnable.span, allOf(notNullValue(), instanceOf(NoopSpan.class)));
+        assertNull("Current span in thread", runnable.span);
     }
 
     @Test
     public void testSubmitCallableWithoutCurrentSpan() throws ExecutionException, InterruptedException {
         Future<Span> threadSpan = subject.submit(new CurrentSpanCallable());
-        assertThat("Current span in thread", threadSpan.get(), allOf(notNullValue(), instanceOf(NoopSpan.class)));
+        assertNull("Current span in thread", threadSpan.get());
     }
 
     static class CurrentSpanRunnable implements Runnable {

--- a/src/test/java/io/opentracing/contrib/spanmanager/concurrent/SpanPropagatingExecutorServiceTest.java
+++ b/src/test/java/io/opentracing/contrib/spanmanager/concurrent/SpanPropagatingExecutorServiceTest.java
@@ -150,14 +150,14 @@ public class SpanPropagatingExecutorServiceTest {
 
         @Override
         public void run() {
-            span = spanManager.currentSpan().getSpan();
+            span = spanManager.currentSpan();
         }
     }
 
     static class CurrentSpanCallable implements Callable<Span> {
         @Override
         public Span call() {
-            return spanManager.currentSpan().getSpan();
+            return spanManager.currentSpan();
         }
     }
 

--- a/src/test/java/io/opentracing/contrib/spanmanager/concurrent/SpanPropagatingExecutorServiceTest.java
+++ b/src/test/java/io/opentracing/contrib/spanmanager/concurrent/SpanPropagatingExecutorServiceTest.java
@@ -150,14 +150,14 @@ public class SpanPropagatingExecutorServiceTest {
 
         @Override
         public void run() {
-            span = spanManager.currentSpan();
+            span = spanManager.currentSpan().getSpan();
         }
     }
 
     static class CurrentSpanCallable implements Callable<Span> {
         @Override
         public Span call() {
-            return spanManager.currentSpan();
+            return spanManager.currentSpan().getSpan();
         }
     }
 


### PR DESCRIPTION
Found an issue when trying to instrument Camel - the `SpanManager` returns a `ManagedSpan` when managing a span - but that span can only be released via the `ManagedSpan`.

If the instrumented application needs to `manage` and `release` in separate locations (i.e. separate callbacks on an exchange handler), then it is not possible to perform the release without stashing the ManagedSpan somewhere - which is the precise problem it is trying to solve.

This PR makes a slight change to the SpanManager API so that it returns a `ManagedSpan` when calling `currentSpan()` (method could be renamed, e.g. 'current()'?), allowing the code that finishes the span to then release it. The other approach that could be used would be to add a `release` method to the `SpanManager` to obtain the `refreshCurrent()` value and release it - which would be less of a change? Happy to discuss alternatives.

@sjoerdtalsma Comments appreciated.