### PR TITLE
Rename manage/release to activate/deactivate.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,22 +16,22 @@ Only tracing-related code will need access to a SpanManager reference, provided 
 
 SpanManager provides the following methods:
 
- 1. `manage(span)` makes the given span the _current_ managed span.  
-    Returns a `ManagedSpan` containing a `release()` method
+ 1. `activate(span)` makes the given span the _current_ managed span.  
+    Returns a `ManagedSpan` containing a `deactivate()` method
     to later 'unmanage' the span with.
  2. `current()` returns the _current_ `ManagedSpan`,
-    or an empty managed span object without a `Span` if no span is managed.
+    or an empty managed span object without a `Span` if no span is activated.
  3. `clear()` provides unconditional cleanup of _all managed spans_ for the current process.
 
 ## DefaultSpanManager
 
 A _default_ SpanManager maintaining a `Stack`-like `ThreadLocal` storage of _linked managed spans_.
 
-Releasing a _linked managed span_ uses the following algorithm:
- 1. If the released span is not the _current_ span, the current span is left alone.
- 2. Otherwise, the first parent that is <em>not yet released</em> is set as the new current span.
+Deactivating a _linked managed span_ uses the following algorithm:
+ 1. If the deactivated span is not the _current_ span, the current span is left alone.
+ 2. Otherwise, the first parent that is <em>not yet deactivated</em> is set as the new current span.
  3. If no current parents remain, the current span is cleared.
- 4. Consecutive `release()` calls for already-released spans will be ignored.
+ 4. Consecutive `deactivate()` calls for already-deactivated spans will be ignored.
 
 ## Concurrency
 
@@ -58,8 +58,8 @@ Contains factory-methods similar to standard java `Executors`:
 This convenience `Tracer` automates managing the _current span_:
  1. It wraps another `Tracer`.
  2. `Spans` created with this tracer are:
-    - automatically _managed_ when started, and
-    - automatically _released_ when finished.
+    - automatically _activated_ when started, and
+    - automatically _deactivated_ when finished.
 
 ## Examples
 
@@ -88,12 +88,12 @@ remembered by the `Runnable`:
         
         @Override
         public void run() {
-            try (ManagedSpan parent = spanManager.manage(currentSpanFromCaller)) {
+            try (ManagedSpan parent = spanManager.activate(currentSpanFromCaller)) {
 
                 // Any background code that requires tracing
                 // and may use spanManager.current().getSpan()
                 
-            } // parent.release() restores spanManager.current()
+            } // parent.deactivate() restores spanManager.current()
         }
     }
 ```
@@ -109,13 +109,13 @@ Then the application can propagate this _current_ Span into background threads:
             ExampleRunnable runnable = new ExampleRunnable(spanManager);
 
             try (Span appSpan = tracer.buildSpan("main").start();           // start appSpan
-                    ManagedSpan managed = spanManager.manage(appSpan)) {    // update current Span
+                    ManagedSpan managed = spanManager.activate(appSpan)) {  // update current Span
             
                 Thread example = new Thread(runnable.withCurrentSpan());
                 example.start();
                 example.join();
                 
-            } // managed.release() + appSpan.finish()
+            } // managed.deactivate() + appSpan.finish()
             
             System.exit(0);
         }
@@ -142,7 +142,7 @@ Then the application can propagate this _current_ Span into background threads:
 
         void run() {
             // ...code that sets the current Span somewhere:
-            try (ManagedSpan current = spanManager.manage(someSpan)) {
+            try (ManagedSpan current = spanManager.activate(someSpan)) {
                 
                 // scheduling the traced call:
                 Future<String> result = threadpool.submit(new TracedCall());
@@ -158,13 +158,13 @@ Then the application can propagate this _current_ Span into background threads:
 When starting a new span and making it the _current_ Span, the manual example above used:
 ```java
     try (Span span = tracer.buildSpan("main").start();           // start span
-            ManagedSpan managed = spanManager.manage(span)) {    // update current Span
+            ManagedSpan managed = spanManager.activate(span)) {  // update current Span
         // ...traced block of code...
     }
 ```
 
 The `ManagedSpanTracer` automatically makes every started span the current span.
-It also releases it again when the span is finished:
+It also deactivates it again when the span is finished:
 
 ```java
     class Caller {
@@ -178,7 +178,7 @@ It also releases it again when the span is finished:
                 // Scheduling the traced call:
                 Future<String> result = threadpool.submit(new TracedCall());
                 
-            } // parent.finish() + ((ManagedSpan) parent).release()
+            } // parent.finish() + ((ManagedSpan) parent).deactivate()
         }
     }
 ```
@@ -191,7 +191,7 @@ a `try-with-resources` code block is insufficient.
 Existing filters that start / finish new spans asynchronously can simply 
 be supplied with the `ManagedSpanTracer` around the existing tracer.
 This sets the _current_ Span from the request filter
-and calls `release()` automatically from the response filter
+and calls `deactivate()` automatically from the response filter
 when the existing filter finishes the span.  
 An example would be using the [opentracing jaxrs filters](https://github.com/opentracing-contrib/java-jaxrs) 
 in combination with the ManagedSpanTracer:
@@ -205,7 +205,7 @@ Handling the request:
     final SpanManager spanManager = ... // inject or DefaultSpanManager.getInstance();
     void onRequest(RequestContext reqCtx) {
         Span span = ... // either obtain Span from previous filter or start from the request
-        ManagedSpan managedSpan = spanManager.manage(span); // span is now current Span.
+        ManagedSpan managedSpan = spanManager.activate(span); // span is now current Span.
         reqCtx.put(SOMEKEY, managedSpan);
     }
 ```
@@ -217,7 +217,7 @@ For the response:
         spanManager.clear(); // Clear stack containing the current Span if this is a boundary-filter
         // or: 
         // ManagedSpan managedSpan = reqCtx.get(SOMEKEY);
-        // managedSpan.release();
+        // managedSpan.deactivate();
         
         // If the corresponding request filter starts a span, don't forget to call span.finish() here!
     }

--- a/src/main/java/io/opentracing/contrib/spanmanager/DefaultSpanManager.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/DefaultSpanManager.java
@@ -71,7 +71,7 @@ public final class DefaultSpanManager implements SpanManager {
     }
 
     @Override
-    public SpanManager.ManagedSpan manage(Span span) {
+    public SpanManager.ManagedSpan activate(Span span) {
         LinkedManagedSpan managedSpan = new LinkedManagedSpan(span, refreshCurrent());
         managed.set(managedSpan);
         return managedSpan;
@@ -95,6 +95,15 @@ public final class DefaultSpanManager implements SpanManager {
         return current.getSpan() != null ? current.getSpan() : NoopSpan.INSTANCE;
     }
 
+    /**
+     * @see #activate(Span)
+     * @deprecated renamed to activate()
+     */
+    @Deprecated
+    public SpanManager.ManagedSpan manage(Span span) {
+        return activate(span);
+    }
+
     @Override
     public String toString() {
         return getClass().getSimpleName();
@@ -115,7 +124,7 @@ public final class DefaultSpanManager implements SpanManager {
             return span;
         }
 
-        public void release() {
+        public void deactivate() {
             if (released.compareAndSet(false, true)) {
                 LinkedManagedSpan current = refreshCurrent(); // Trigger stack-unwinding algorithm.
                 LOGGER.log(Level.FINER, "Released {0}, current span is {1}.", new Object[]{this, current});
@@ -126,7 +135,16 @@ public final class DefaultSpanManager implements SpanManager {
 
         @Override
         public void close() {
-            release();
+            deactivate();
+        }
+
+        /**
+         * @see #deactivate()
+         * @deprecated renamed to deactivate()
+         */
+        @Deprecated
+        public void release() {
+            deactivate();
         }
 
         @Override
@@ -148,7 +166,7 @@ public final class DefaultSpanManager implements SpanManager {
         }
 
         @Override
-        public void release() {
+        public void deactivate() {
             // no-op
         }
 

--- a/src/main/java/io/opentracing/contrib/spanmanager/SpanManager.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/SpanManager.java
@@ -31,32 +31,32 @@ public interface SpanManager {
      * Makes span the <em>current span</em> within the running process.
      *
      * @param span The span to become the current span.
-     * @return A managed object containing the current span and a way to release it again.
+     * @return A managed object containing the current span and a way to deactivate it again.
      * @see SpanManager#current()
-     * @see ManagedSpan#release()
+     * @see ManagedSpan#deactivate()
      */
-    ManagedSpan manage(Span span);
+    ManagedSpan activate(Span span);
 
     /**
      * Retrieve the current {@link ManagedSpan managed span}.
      * <p>
      * If there is no current managed span, an 'empty' managed span instance is returned
-     * for which {@link ManagedSpan#release() release()} has no effects
+     * for which {@link ManagedSpan#deactivate() deactivate()} has no effects
      * and whose {@link ManagedSpan#getSpan() getSpan()} method always returns {@code null}.
      *
      * @return The current managed span
-     * @see SpanManager#manage(Span)
+     * @see SpanManager#activate(Span)
      */
     ManagedSpan current();
 
     /**
      * Unconditional cleanup of all managed spans including any parents.
      * <p>
-     * This allows boundary filters to release all current spans
+     * This allows boundary filters to deactivate all current spans
      * before relinquishing control over their process,
      * which may end up repurposed by a threadpool.
      *
-     * @see ManagedSpan#release()
+     * @see ManagedSpan#deactivate()
      */
     void clear();
 
@@ -69,16 +69,16 @@ public interface SpanManager {
      * which is safe, as curren
      *
      * @return The current Span, or the <code>NoopSpan</code> if there is no managed span.
-     * @see SpanManager#manage(Span)
+     * @see SpanManager#activate(Span)
      * @see SpanManager#current()
      * @deprecated Please use <code>SpanManager.current().getSpan()</code> instead
      */
     Span currentSpan();
 
     /**
-     * To {@linkplain #release() release} a {@link SpanManager#manage(Span) managed span} with.
+     * To {@linkplain #deactivate() deactivate} a {@link SpanManager#activate(Span) managed active span} with.
      * <p>
-     * It must be possible to repeatedly call {@linkplain #release()} without side effects.
+     * It must be possible to repeatedly call {@linkplain #deactivate()} without side effects.
      *
      * @see SpanManager
      */
@@ -87,7 +87,7 @@ public interface SpanManager {
         /**
          * The span that became the managed span at some point.
          *
-         * @return The contained span to be released, or <code>null</code> if no span is being managed.
+         * @return The contained span that was activated, or <code>null</code> if no span is being managed.
          */
         Span getSpan();
 
@@ -96,15 +96,15 @@ public interface SpanManager {
          * <p>
          * Implementation notes:
          * <ol>
-         * <li>It is encouraged to restore the managed span as it was before this span became managed
+         * <li>It is encouraged to restore the managed span as it was before this span was activated
          * (providing stack-like behaviour).</li>
-         * <li>It must be possible to repeatedly call <code>release</code> without side effects.</li>
+         * <li>It must be possible to repeatedly call <code>deactivate</code> without side effects.</li>
          * </ol>
          */
-        void release();
+        void deactivate();
 
         /**
-         * Alias for {@link #release()} to allow easy use from try-with-resources.
+         * Alias for {@link #deactivate()} to allow easy use from try-with-resources.
          */
         void close();
 

--- a/src/main/java/io/opentracing/contrib/spanmanager/concurrent/CallableWithManagedSpan.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/concurrent/CallableWithManagedSpan.java
@@ -19,7 +19,7 @@ import io.opentracing.contrib.spanmanager.SpanManager;
 import java.util.concurrent.Callable;
 
 /**
- * {@link Callable} wrapper that will execute with a {@link SpanManager#manage(Span) managed span}
+ * {@link Callable} wrapper that will execute with an {@link SpanManager#activate(Span) managed active span}
  * specified from the scheduling thread.
  *
  * @see SpanManager
@@ -45,11 +45,11 @@ final class CallableWithManagedSpan<T> implements Callable<T> {
      * @throws Exception if the original call threw an exception.
      */
     public T call() throws Exception {
-        SpanManager.ManagedSpan managedSpan = spanManager.manage(spanToManage);
+        SpanManager.ManagedSpan managedSpan = spanManager.activate(spanToManage);
         try {
             return delegate.call();
         } finally {
-            managedSpan.release();
+            managedSpan.deactivate();
         }
     }
 

--- a/src/main/java/io/opentracing/contrib/spanmanager/concurrent/RunnableWithManagedSpan.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/concurrent/RunnableWithManagedSpan.java
@@ -17,7 +17,7 @@ import io.opentracing.Span;
 import io.opentracing.contrib.spanmanager.SpanManager;
 
 /**
- * {@link Runnable} wrapper that will execute with a {@link SpanManager#manage(Span) managed span}
+ * {@link Runnable} wrapper that will execute with a {@link SpanManager#activate(Span) managed active span}
  * specified from the scheduling thread.
  *
  * @see SpanManager
@@ -40,11 +40,11 @@ final class RunnableWithManagedSpan implements Runnable {
      * Performs the runnable action with the specified managed span.
      */
     public void run() {
-        SpanManager.ManagedSpan managedSpan = spanManager.manage(spanToManage);
+        SpanManager.ManagedSpan managedSpan = spanManager.activate(spanToManage);
         try {
             delegate.run();
         } finally {
-            managedSpan.release();
+            managedSpan.deactivate();
         }
     }
 

--- a/src/main/java/io/opentracing/contrib/spanmanager/tracer/AutoReleasingManagedSpan.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/tracer/AutoReleasingManagedSpan.java
@@ -20,7 +20,7 @@ import io.opentracing.contrib.spanmanager.SpanManager;
 import java.util.Map;
 
 /**
- * A {@link Span} that automatically {@link #release() releases}
+ * A {@link Span} that automatically {@link #deactivate() deactivates}
  * when {@link #finish() finished} or {@link #close() closed}.
  * <p>
  * All other methods are forwarded to the actual managed Span.
@@ -43,43 +43,43 @@ final class AutoReleasingManagedSpan implements Span, SpanManager.ManagedSpan {
      * Releases this current ManagedSpan.
      */
     @Override
-    public void release() {
-        managedSpan.release();
+    public void deactivate() {
+        managedSpan.deactivate();
     }
 
     /**
-     * {@link Span#finish() Finishes} the delegate and {@link SpanManager.ManagedSpan#release() releases} this ManagedSpan.
+     * {@link Span#finish() Finishes} the delegate and {@link SpanManager.ManagedSpan#deactivate() releases} this ManagedSpan.
      */
     @Override
     public void finish() {
         try {
             getSpan().finish();
         } finally {
-            release();
+            deactivate();
         }
     }
 
     /**
-     * {@link Span#finish(long) Finishes} the delegate and {@link SpanManager.ManagedSpan#release() releases} this ManagedSpan.
+     * {@link Span#finish(long) Finishes} the delegate and {@link SpanManager.ManagedSpan#deactivate() releases} this ManagedSpan.
      */
     @Override
     public void finish(long finishMicros) {
         try {
             getSpan().finish(finishMicros);
         } finally {
-            release();
+            deactivate();
         }
     }
 
     /**
-     * {@link Span#close() Closes} the delegate and {@link SpanManager.ManagedSpan#release() releases} this ManagedSpan.
+     * {@link Span#close() Closes} the delegate and {@link SpanManager.ManagedSpan#deactivate() releases} this ManagedSpan.
      */
     @Override
     public void close() {
         try {
             getSpan().close();
         } finally {
-            release();
+            deactivate();
         }
     }
 

--- a/src/main/java/io/opentracing/contrib/spanmanager/tracer/ManagedSpanBuilder.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/tracer/ManagedSpanBuilder.java
@@ -22,10 +22,10 @@ import io.opentracing.contrib.spanmanager.SpanManager;
 import java.util.Map;
 
 /**
- * {@link SpanBuilder} that automatically {@link SpanManager#manage(Span) activates} newly started spans.
+ * {@link SpanBuilder} that automatically {@link SpanManager#activate(Span) activates} newly started spans.
  * <p>
  * The activated ManagedSpan is wrapped in an {@linkplain AutoReleasingManagedSpan}
- * to automatically release when finished.<br>
+ * to automatically deactivate when finished.<br>
  * All other methods are forwarded to the delegate span builder.
  *
  * @see SpanManager
@@ -57,15 +57,15 @@ final class ManagedSpanBuilder implements SpanBuilder {
     }
 
     /**
-     * Starts the built Span and {@link SpanManager#manage(Span) activates} it.
+     * Starts the built Span and {@link SpanManager#activate(Span) activates} it.
      *
      * @return a new 'current' Span that releases itself upon <em>finish</em> or <em>close</em> calls.
-     * @see SpanManager#manage(Span)
-     * @see AutoReleasingManagedSpan#release()
+     * @see SpanManager#activate(Span)
+     * @see AutoReleasingManagedSpan#deactivate()
      */
     @Override
     public Span start() {
-        return new AutoReleasingManagedSpan(spanManager.manage(delegate.start()));
+        return new AutoReleasingManagedSpan(spanManager.activate(delegate.start()));
     }
 
     // All other methods are forwarded to the delegate SpanBuilder.

--- a/src/main/java/io/opentracing/contrib/spanmanager/tracer/ManagedSpanTracer.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/tracer/ManagedSpanTracer.java
@@ -24,8 +24,8 @@ import io.opentracing.propagation.Format;
  * <ol>
  * <li>It is a wrapper that forwards all calls to another {@link Tracer} implementation.</li>
  * <li>{@linkplain Span Spans} created with this tracer are
- * automatically {@link SpanManager#manage(Span) managed} when started,</li>
- * <li>and automatically {@link SpanManager.ManagedSpan#release() released} when they finish.</li>
+ * automatically {@link SpanManager#activate(Span) activated} when started,</li>
+ * <li>and automatically {@link SpanManager.ManagedSpan#deactivate() deactivated} when they finish.</li>
  * </ol>
  * <p>
  * Implementation note: This {@link Tracer} wraps the {@linkplain SpanBuilder} and {@linkplain Span}

--- a/src/test/java/io/opentracing/contrib/spanmanager/concurrent/SpanPropagatingExecutorServiceTest.java
+++ b/src/test/java/io/opentracing/contrib/spanmanager/concurrent/SpanPropagatingExecutorServiceTest.java
@@ -13,7 +13,6 @@
  */
 package io.opentracing.contrib.spanmanager.concurrent;
 
-import io.opentracing.NoopSpan;
 import io.opentracing.Span;
 import io.opentracing.contrib.spanmanager.DefaultSpanManager;
 import io.opentracing.contrib.spanmanager.SpanManager;
@@ -60,7 +59,7 @@ public class SpanPropagatingExecutorServiceTest {
     @Test
     public void testExecuteRunnable() throws ExecutionException, InterruptedException {
         CurrentSpanRunnable runnable = new CurrentSpanRunnable();
-        ManagedSpan callerManagedSpan = spanManager.manage(mock(Span.class));
+        ManagedSpan callerManagedSpan = spanManager.activate(mock(Span.class));
         try {
 
             // Execute runnable and wait for completion.
@@ -70,35 +69,35 @@ public class SpanPropagatingExecutorServiceTest {
 
             assertThat("Current span in thread", runnable.span, is(sameInstance(callerManagedSpan.getSpan())));
         } finally {
-            callerManagedSpan.release();
+            callerManagedSpan.deactivate();
         }
     }
 
     @Test
     public void testSubmitRunnable() throws ExecutionException, InterruptedException {
         CurrentSpanRunnable runnable = new CurrentSpanRunnable();
-        ManagedSpan callerManagedSpan = spanManager.manage(mock(Span.class));
+        ManagedSpan callerManagedSpan = spanManager.activate(mock(Span.class));
         try {
 
             subject.submit(runnable).get(); // submit and block.
             assertThat("Current span in thread", runnable.span, is(sameInstance(callerManagedSpan.getSpan())));
 
         } finally {
-            callerManagedSpan.release();
+            callerManagedSpan.deactivate();
         }
     }
 
     @Test
     public void testSubmitCallable() throws ExecutionException, InterruptedException {
         Callable<Span> callable = new CurrentSpanCallable();
-        ManagedSpan callerManagedSpan = spanManager.manage(mock(Span.class));
+        ManagedSpan callerManagedSpan = spanManager.activate(mock(Span.class));
         try {
 
             Future<Span> threadSpan = subject.submit(callable);
             assertThat("Current span in thread", threadSpan.get(), is(sameInstance(callerManagedSpan.getSpan())));
 
         } finally {
-            callerManagedSpan.release();
+            callerManagedSpan.deactivate();
         }
     }
 
@@ -106,7 +105,7 @@ public class SpanPropagatingExecutorServiceTest {
     public void testInvokeAll() throws ExecutionException, InterruptedException {
         Collection<Callable<Span>> callables = Arrays.<Callable<Span>>asList(
                 new CurrentSpanCallable(), new CurrentSpanCallable(), new CurrentSpanCallable());
-        ManagedSpan callerManagedSpan = spanManager.manage(mock(Span.class));
+        ManagedSpan callerManagedSpan = spanManager.activate(mock(Span.class));
         try {
 
             List<Future<Span>> futures = subject.invokeAll(callables);
@@ -116,7 +115,7 @@ public class SpanPropagatingExecutorServiceTest {
             }
 
         } finally {
-            callerManagedSpan.release();
+            callerManagedSpan.deactivate();
         }
     }
 


### PR DESCRIPTION
The terms _activate_ and _deactivate_ seemed more appropriate than _manage_ and _release_, as became apparent during the Distributed Tracing workshop in Berlin.

I think it is wise to tackle unclear naming while the library still is in the 'work in progress' stage.