### PR TITLE
Use OpenTracing API version 0.22.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <build.java.version>1.6</build.java.version>
 
-        <opentracing-api.version>0.21.0</opentracing-api.version>
+        <opentracing-api.version>0.22.0</opentracing-api.version>
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>1.10.19</mockito.version>

--- a/src/main/java/io/opentracing/contrib/spanmanager/concurrent/CallableWithManagedSpan.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/concurrent/CallableWithManagedSpan.java
@@ -44,6 +44,7 @@ final class CallableWithManagedSpan<T> implements Callable<T> {
      * @return The result from the original call.
      * @throws Exception if the original call threw an exception.
      */
+    @Override
     public T call() throws Exception {
         SpanManager.ManagedSpan managedSpan = spanManager.activate(spanToManage);
         try {

--- a/src/main/java/io/opentracing/contrib/spanmanager/concurrent/RunnableWithManagedSpan.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/concurrent/RunnableWithManagedSpan.java
@@ -39,6 +39,7 @@ final class RunnableWithManagedSpan implements Runnable {
     /**
      * Performs the runnable action with the specified managed span.
      */
+    @Override
     public void run() {
         SpanManager.ManagedSpan managedSpan = spanManager.activate(spanToManage);
         try {

--- a/src/main/java/io/opentracing/contrib/spanmanager/tracer/ManagedSpanBuilder.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/tracer/ManagedSpanBuilder.java
@@ -19,7 +19,9 @@ import io.opentracing.SpanContext;
 import io.opentracing.Tracer.SpanBuilder;
 import io.opentracing.contrib.spanmanager.SpanManager;
 
+import java.util.Collections;
 import java.util.Map;
+import java.util.logging.Logger;
 
 /**
  * {@link SpanBuilder} that automatically {@link SpanManager#activate(Span) activates} newly started spans.
@@ -79,9 +81,6 @@ final class ManagedSpanBuilder implements SpanBuilder {
     }
 
     public SpanBuilder addReference(String referenceType, SpanContext context) {
-        if (context instanceof ManagedSpanBuilder) { // Weird that SpanBuilder extends Context!
-            context = ((ManagedSpanBuilder) context).delegate;
-        }
         return rewrap(delegate.addReference(referenceType, context));
     }
 
@@ -101,8 +100,14 @@ final class ManagedSpanBuilder implements SpanBuilder {
         return rewrap(delegate.withStartTimestamp(microseconds));
     }
 
+    /**
+     * @return Empty set of baggage items.
+     * @deprecated Don't call this anymore, SpanBuilder and SpanContext are separated since opentracing-api v0.22.0.
+     */
     public Iterable<Map.Entry<String, String>> baggageItems() {
-        return delegate.baggageItems();
+        Logger.getLogger(getClass().getName())
+                .warning("SpanContext baggageItems() method called for SpanBuilder!");
+        return Collections.<String, String>emptyMap().entrySet();
     }
 
 }

--- a/src/main/java/io/opentracing/contrib/spanmanager/tracer/ManagedSpanBuilder.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/tracer/ManagedSpanBuilder.java
@@ -72,30 +72,37 @@ final class ManagedSpanBuilder implements SpanBuilder {
 
     // All other methods are forwarded to the delegate SpanBuilder.
 
+    @Override
     public SpanBuilder asChildOf(SpanContext parent) {
         return addReference(References.CHILD_OF, parent);
     }
 
+    @Override
     public SpanBuilder asChildOf(Span parent) {
         return addReference(References.CHILD_OF, parent.context());
     }
 
+    @Override
     public SpanBuilder addReference(String referenceType, SpanContext context) {
         return rewrap(delegate.addReference(referenceType, context));
     }
 
+    @Override
     public SpanBuilder withTag(String key, String value) {
         return rewrap(delegate.withTag(key, value));
     }
 
+    @Override
     public SpanBuilder withTag(String key, boolean value) {
         return rewrap(delegate.withTag(key, value));
     }
 
+    @Override
     public SpanBuilder withTag(String key, Number value) {
         return rewrap(delegate.withTag(key, value));
     }
 
+    @Override
     public SpanBuilder withStartTimestamp(long microseconds) {
         return rewrap(delegate.withStartTimestamp(microseconds));
     }

--- a/src/main/java/io/opentracing/contrib/spanmanager/tracer/ManagedSpanTracer.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/tracer/ManagedSpanTracer.java
@@ -55,9 +55,6 @@ public final class ManagedSpanTracer implements Tracer {
     }
 
     public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {
-        if (spanContext instanceof ManagedSpanBuilder) { // Weird that SpanBuilder extends Context!
-            spanContext = ((ManagedSpanBuilder) spanContext).delegate;
-        }
         delegate.inject(spanContext, format, carrier);
     }
 

--- a/src/main/java/io/opentracing/contrib/spanmanager/tracer/ManagedSpanTracer.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/tracer/ManagedSpanTracer.java
@@ -54,14 +54,17 @@ public final class ManagedSpanTracer implements Tracer {
         this.spanManager = spanManager;
     }
 
+    @Override
     public <C> void inject(SpanContext spanContext, Format<C> format, C carrier) {
         delegate.inject(spanContext, format, carrier);
     }
 
+    @Override
     public <C> SpanContext extract(Format<C> format, C carrier) {
         return delegate.extract(format, carrier);
     }
 
+    @Override
     public SpanBuilder buildSpan(String operationName) {
         return new ManagedSpanBuilder(delegate.buildSpan(operationName), spanManager);
     }


### PR DESCRIPTION
This separates the `SpanBuilder` and `SpanContext` concepts which were previously conflated.