### PR TITLE
upgrade to latest opentracing-api

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,12 +21,12 @@
     <!-- Artifact identification -->
     <groupId>io.opentracing.contrib</groupId>
     <artifactId>opentracing-spanmanager</artifactId>
-    <version>0.0.6-SNAPSHOT</version>
+    <version>0.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <!-- Project information -->
     <name>SpanManager library</name>
-    <description>Manager of current span and propagating it accross threads</description>
+    <description>Manager of current span and propagating it across threads</description>
     <url>https://github.com/opentracing-contrib/java-spanmanager</url>
     <inceptionYear>2017</inceptionYear>
 
@@ -43,7 +43,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <build.java.version>1.6</build.java.version>
 
-        <opentracing-api.version>0.22.0</opentracing-api.version>
+        <opentracing-api.version>0.30.0</opentracing-api.version>
         <junit.version>4.12</junit.version>
         <hamcrest.version>1.3</hamcrest.version>
         <mockito.version>1.10.19</mockito.version>

--- a/src/main/java/io/opentracing/contrib/spanmanager/tracer/AutoReleasingManagedSpan.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/tracer/AutoReleasingManagedSpan.java
@@ -72,12 +72,12 @@ final class AutoReleasingManagedSpan implements Span, SpanManager.ManagedSpan {
     }
 
     /**
-     * {@link Span#close() Closes} the delegate and {@link SpanManager.ManagedSpan#deactivate() releases} this ManagedSpan.
+     * {@link Span#finish() Closes} the delegate and {@link SpanManager.ManagedSpan#deactivate() releases} this ManagedSpan.
      */
     @Override
     public void close() {
         try {
-            getSpan().close();
+            getSpan().finish();
         } finally {
             deactivate();
         }

--- a/src/main/java/io/opentracing/contrib/spanmanager/tracer/ManagedSpanBuilder.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/tracer/ManagedSpanBuilder.java
@@ -13,9 +13,12 @@
  */
 package io.opentracing.contrib.spanmanager.tracer;
 
+import io.opentracing.ActiveSpan;
+import io.opentracing.BaseSpan;
 import io.opentracing.References;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
 import io.opentracing.Tracer.SpanBuilder;
 import io.opentracing.contrib.spanmanager.SpanManager;
 
@@ -74,17 +77,22 @@ final class ManagedSpanBuilder implements SpanBuilder {
 
     @Override
     public SpanBuilder asChildOf(SpanContext parent) {
-        return addReference(References.CHILD_OF, parent);
+        return rewrap(addReference(References.CHILD_OF, parent));
     }
 
     @Override
-    public SpanBuilder asChildOf(Span parent) {
-        return addReference(References.CHILD_OF, parent.context());
+    public SpanBuilder asChildOf(final BaseSpan<?> parent) {
+        return rewrap(addReference(References.CHILD_OF, parent.context()));
     }
 
     @Override
     public SpanBuilder addReference(String referenceType, SpanContext context) {
         return rewrap(delegate.addReference(referenceType, context));
+    }
+
+    @Override
+    public SpanBuilder ignoreActiveSpan() {
+        return rewrap(delegate.ignoreActiveSpan());
     }
 
     @Override
@@ -105,6 +113,16 @@ final class ManagedSpanBuilder implements SpanBuilder {
     @Override
     public SpanBuilder withStartTimestamp(long microseconds) {
         return rewrap(delegate.withStartTimestamp(microseconds));
+    }
+
+    @Override
+    public ActiveSpan startActive() {
+        return delegate.startActive();
+    }
+
+    @Override
+    public Span startManual() {
+        return delegate.startManual();
     }
 
     /**

--- a/src/main/java/io/opentracing/contrib/spanmanager/tracer/ManagedSpanTracer.java
+++ b/src/main/java/io/opentracing/contrib/spanmanager/tracer/ManagedSpanTracer.java
@@ -13,6 +13,7 @@
  */
 package io.opentracing.contrib.spanmanager.tracer;
 
+import io.opentracing.ActiveSpan;
 import io.opentracing.Span;
 import io.opentracing.SpanContext;
 import io.opentracing.Tracer;
@@ -74,4 +75,13 @@ public final class ManagedSpanTracer implements Tracer {
         return "ManagedSpanTracer{" + delegate + '}';
     }
 
+    @Override
+    public ActiveSpan activeSpan() {
+        return delegate.activeSpan();
+    }
+
+    @Override
+    public ActiveSpan makeActive(final Span span) {
+        return delegate.makeActive(span);
+    }
 }


### PR DESCRIPTION
There are some api changes in opentracing-api 0.30.0. This change
bumps the opentracing-api version in the pom and fixes spanmanager
to be compatible with the those opentracing api changes